### PR TITLE
feat: support parsing variable-length tokens followed by fixed-length  tokens

### DIFF
--- a/calver_test.go
+++ b/calver_test.go
@@ -186,6 +186,22 @@ func TestParse(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"YYYY.MMDD.MICRO", "2026.123.0",
+			&Calver{
+				micro: 0,
+				ts:    time.Date(2026, time.Month(12), 3, 0, 0, 0, 0, time.UTC),
+			},
+			false,
+		},
+		{
+			"YYYY.MM0D.MICRO", "2026.123.0",
+			&Calver{
+				micro: 0,
+				ts:    time.Date(2026, time.Month(1), 23, 0, 0, 0, 0, time.UTC),
+			},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s/%s", tt.layout, tt.value), func(t *testing.T) {


### PR DESCRIPTION
Add support for layouts like `YYYY.MM0D.MICRO` where a variable-length token (`MM`) is followed by a fixed-length token (`0D`) without a separator.

When parsing `2026.123.0` with `YYYY.MM0D.MICRO`, the parser now correctly interprets it as January 23rd by reserving enough characters for the subsequent fixed-length token.